### PR TITLE
Add support for fmt::text_style

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -1,5 +1,5 @@
 #include <oxen/log.hpp>
-
+#include <fmt/color.h>
 
 int main() {
     using namespace oxen::log;
@@ -36,4 +36,17 @@ int main() {
     set_level(cat_bar, Level::debug);
     info(cat_foo, "hello {}", 42);
     info(cat_bar, "hello {}", 42);
+
+    info(cat_bar, fg(fmt::color::green), "green!");
+    info(cat_bar, fg(fmt::color::red), "red!");
+    critical(
+            cat_foo,
+            fg(fmt::color::black) | bg(fmt::color::yellow) | fmt::emphasis::bold |
+                    fmt::emphasis::underline | fmt::emphasis::italic,
+            "BLACK");
+    error(cat_foo,
+          fg(fmt::color::white) | bg(fmt::color::red) | fmt::emphasis::bold |
+                  fmt::emphasis::underline | fmt::emphasis::italic,
+          "WHITE {}",
+          42);
 }

--- a/include/oxen/log.hpp
+++ b/include/oxen/log.hpp
@@ -11,6 +11,7 @@
 #include "log/source_location.hpp"
 #include "log/level.hpp"
 #include "log/type.hpp"
+#include "log/color.hpp"
 #include "log/internal.hpp"
 #include "log/catlogger.hpp"
 
@@ -37,11 +38,29 @@ struct trace {
                   slns::source_location::current()) {
 #if defined(NDEBUG) && !defined(OXEN_LOGGING_RELEASE_TRACE)
         // Using [[maybe_unused]] on the *first* ctor argument breaks gcc 8/9
-        (void) cat_logger;
+        (void)cat_logger;
 #else
         if (cat_logger)
             cat_logger->log(
                     detail::spdlog_sloc(location), Level::trace, fmt, std::forward<T>(args)...);
+#endif
+    }
+    trace(const logger_ptr& cat_logger,
+          [[maybe_unused]] const fmt::text_style& sty,
+          [[maybe_unused]] fmt::format_string<T...> fmt,
+          [[maybe_unused]] T&&... args,
+          [[maybe_unused]] const slns::source_location& location =
+                  slns::source_location::current()) {
+#if defined(NDEBUG) && !defined(OXEN_LOGGING_RELEASE_TRACE)
+        // Using [[maybe_unused]] on the *first* ctor argument breaks gcc 8/9
+        (void)cat_logger;
+#else
+        if (cat_logger)
+            cat_logger->log(
+                    detail::spdlog_sloc(location),
+                    Level::trace,
+                    "{}",
+                    detail::text_style_wrapper<T...>{sty, fmt, args...});
 #endif
     }
 };
@@ -58,6 +77,18 @@ struct debug {
             cat_logger->log(
                     detail::spdlog_sloc(location), Level::debug, fmt, std::forward<T>(args)...);
     }
+    debug(const logger_ptr& cat_logger,
+          const fmt::text_style& sty,
+          fmt::format_string<T...> fmt,
+          T&&... args,
+          const slns::source_location& location = slns::source_location::current()) {
+        if (cat_logger)
+            cat_logger->log(
+                    detail::spdlog_sloc(location),
+                    Level::debug,
+                    "{}",
+                    detail::text_style_wrapper<T...>{sty, fmt, args...});
+    }
 };
 /// Log a "info" log statement.  Use this as if a function, where the first argument is (typically)
 /// a CategoryLogger, the second argument is an fmt pattern, and the rest of the arguments are
@@ -71,6 +102,18 @@ struct info {
         if (cat_logger)
             cat_logger->log(
                     detail::spdlog_sloc(location), Level::info, fmt, std::forward<T>(args)...);
+    }
+    info(const logger_ptr& cat_logger,
+         const fmt::text_style& sty,
+         fmt::format_string<T...> fmt,
+         T&&... args,
+         const slns::source_location& location = slns::source_location::current()) {
+        if (cat_logger)
+            cat_logger->log(
+                    detail::spdlog_sloc(location),
+                    Level::info,
+                    "{}",
+                    detail::text_style_wrapper<T...>{sty, fmt, args...});
     }
 };
 /// Log a "warning" log statement.  Use this as if a function, where the first argument is
@@ -86,6 +129,18 @@ struct warning {
             cat_logger->log(
                     detail::spdlog_sloc(location), Level::warn, fmt, std::forward<T>(args)...);
     }
+    warning(const logger_ptr& cat_logger,
+            const fmt::text_style& sty,
+            fmt::format_string<T...> fmt,
+            T&&... args,
+            const slns::source_location& location = slns::source_location::current()) {
+        if (cat_logger)
+            cat_logger->log(
+                    detail::spdlog_sloc(location),
+                    Level::warn,
+                    "{}",
+                    detail::text_style_wrapper<T...>{sty, fmt, args...});
+    }
 };
 /// Log a "error" log statement.  Use this as if a function, where the first argument is (typically)
 /// a CategoryLogger, the second argument is an fmt pattern, and the rest of the arguments are
@@ -99,6 +154,18 @@ struct error {
         if (cat_logger)
             cat_logger->log(
                     detail::spdlog_sloc(location), Level::err, fmt, std::forward<T>(args)...);
+    }
+    error(const logger_ptr& cat_logger,
+          const fmt::text_style& sty,
+          fmt::format_string<T...> fmt,
+          T&&... args,
+          const slns::source_location& location = slns::source_location::current()) {
+        if (cat_logger)
+            cat_logger->log(
+                    detail::spdlog_sloc(location),
+                    Level::err,
+                    "{}",
+                    detail::text_style_wrapper<T...>{sty, fmt, args...});
     }
 };
 /// Log a "critical" log statement.  Use this as if a function, where the first argument is
@@ -115,6 +182,19 @@ struct critical {
             cat_logger->log(
                     detail::spdlog_sloc(location), Level::critical, fmt, std::forward<T>(args)...);
     }
+    critical(
+            const logger_ptr& cat_logger,
+            const fmt::text_style& sty,
+            fmt::format_string<T...> fmt,
+            T&&... args,
+            const slns::source_location& location = slns::source_location::current()) {
+        if (cat_logger)
+            cat_logger->log(
+                    detail::spdlog_sloc(location),
+                    Level::critical,
+                    "{}",
+                    detail::text_style_wrapper<T...>{sty, fmt, args...});
+    }
 };
 
 // Deduction guides for our logging function-like structs; these force all arguments given in the
@@ -124,21 +204,39 @@ struct critical {
 // work with the trailing defaulted value).
 template <typename... T>
 trace(const logger_ptr& cat, fmt::format_string<T...> fmt, T&&... args) -> trace<T...>;
+template <typename... T>
+trace(const logger_ptr& cat, const fmt::text_style& sty, fmt::format_string<T...> fmt, T&&... args)
+        -> trace<T...>;
 
 template <typename... T>
 debug(const logger_ptr& cat, fmt::format_string<T...> fmt, T&&... args) -> debug<T...>;
+template <typename... T>
+debug(const logger_ptr& cat, const fmt::text_style& sty, fmt::format_string<T...> fmt, T&&... args)
+        -> debug<T...>;
 
 template <typename... T>
 info(const logger_ptr& cat, fmt::format_string<T...> fmt, T&&... args) -> info<T...>;
+template <typename... T>
+info(const logger_ptr& cat, const fmt::text_style& sty, fmt::format_string<T...> fmt, T&&... args)
+        -> info<T...>;
 
 template <typename... T>
 warning(const logger_ptr& cat, fmt::format_string<T...> fmt, T&&... args) -> warning<T...>;
+template <typename... T>
+warning(const logger_ptr& cat, const fmt::text_style& sty, fmt::format_string<T...> fmt, T&&... args)
+        -> warning<T...>;
 
 template <typename... T>
 error(const logger_ptr& cat, fmt::format_string<T...> fmt, T&&... args) -> error<T...>;
+template <typename... T>
+error(const logger_ptr& cat, const fmt::text_style& sty, fmt::format_string<T...> fmt, T&&... args)
+        -> error<T...>;
 
 template <typename... T>
 critical(const logger_ptr& cat, fmt::format_string<T...> fmt, T&&... args) -> critical<T...>;
+template <typename... T>
+critical(const logger_ptr& cat, const fmt::text_style& sty, fmt::format_string<T...> fmt, T&&... args)
+        -> critical<T...>;
 
 /// Resets the log level of all existing category loggers, and sets a new default for any created
 /// after this call.  If this has not been called, the default log level of category loggers is

--- a/include/oxen/log/color.hpp
+++ b/include/oxen/log/color.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <fmt/color.h>
+#include <tuple>
+
+namespace oxen::log::detail {
+
+// Wraps text_style, fmt, and arguments and outputs them via fmt when formatted.  This is here so
+// that we can use styled text that *won't* go through formatting when the logging level isn't
+// active while still lets us use fmt's text_style to color/emphasize/etc. the text, and avoids
+// double-formatting (if we use fmt::format ourself in the log argument, and the output happens to
+// have {} in it).
+//
+// This object should not be called directly; instead call log::info, etc.  with a text style as
+// first argument.
+template <typename... T>
+struct text_style_wrapper {
+    const fmt::text_style& sty;
+    fmt::basic_string_view<char> fmt;
+    const std::tuple<const T&...> args;
+
+    text_style_wrapper(const fmt::text_style& sty, fmt::format_string<T...> fmt, const T&... args)
+        : sty{sty}, fmt{fmt}, args{std::tie(args...)} {}
+};
+
+}
+
+template <typename... T>
+struct fmt::formatter<oxen::log::detail::text_style_wrapper<T...>> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+    template <typename FormatContext>
+    auto format(const oxen::log::detail::text_style_wrapper<T...>& f, FormatContext& ctx)
+    {
+        auto out = ctx.out();
+        return std::apply(
+                [&](const auto&... args) {
+                    return fmt::format_to(out, f.sty, f.fmt, args...); }, f.args);
+    }
+};


### PR DESCRIPTION
This allows:

```C++
log::info(cat, fg(fmt::color::red), "asdf {}", 42);
```

to print in red foreground text (and any other fmt/color.h styles can be
used).  This has three advantages over:

```C++
log::info(cat, fmt::format(fg(fmt::color::red), "asdf {}", 42));
```

1. Less verbose.
2. Doesn't do formatting unless the log level is low enough to show the message (the version with the fmt::format version always formats).
3. Doesn't double-format, if the fmt::format'ed value ends up having some '{}' format string in it.

![image](https://user-images.githubusercontent.com/4459524/186284793-19797a2e-5703-4554-b886-3e803a126bf2.png)
