### PR TITLE
Add _format user-defined string literal

### DIFF
--- a/include/oxen/log/format.hpp
+++ b/include/oxen/log/format.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+/// This header defines a ""_format user-defined literal that works similarly to fmt::format, but
+/// with a more clever syntax:
+///
+///     fmt::format("xyz {}", 42);
+///
+/// becomes:
+///
+///     "xyz {}"_format(42);
+///
+/// The function lives in the `oxen::log::literals` namespace; you should use it via:
+///
+///     #include <oxen/log/format.hpp>
+///     // ...
+///     using namespace oxen::log::literals;
+///
+/// to make it available (it is not included by default from oxen-logging headers).
+
+#include <fmt/core.h>
+#include <string_view>
+
+namespace oxen::log {
+
+namespace detail {
+
+    // Internal implementation of _format that holds the format temporarily until the (...) operator
+    // is invoked on it.  This object cannot be moved, copied but only used ephemerally in-place.
+    struct fmt_wrapper {
+      private:
+        std::string_view format;
+
+        // Non-copyable and non-movable:
+        fmt_wrapper(const fmt_wrapper&) = delete;
+        fmt_wrapper& operator=(const fmt_wrapper&) = delete;
+        fmt_wrapper(fmt_wrapper&&) = delete;
+        fmt_wrapper& operator=(fmt_wrapper&&) = delete;
+
+      public:
+        constexpr explicit fmt_wrapper(const char* str, const std::size_t len) : format{str, len} {}
+
+        /// Calling on this object forwards all the values to fmt::format, using the format string
+        /// as provided during construction (via the "..."_format user-defined function).
+        template <typename... T>
+        auto operator()(T&&... args) && {
+            return fmt::format(format, std::forward<T>(args)...);
+        }
+    };
+
+}  // namespace detail
+
+inline namespace literals {
+
+    inline detail::fmt_wrapper operator""_format(const char* str, size_t len) {
+        return detail::fmt_wrapper{str, len};
+    }
+
+}  // namespace literals
+
+}  // namespace oxen::log

--- a/src/level.cpp
+++ b/src/level.cpp
@@ -1,5 +1,6 @@
 #include <oxen/log/level.hpp>
 #include <oxen/log/internal.hpp>
+#include <oxen/log/format.hpp>
 #include <stdexcept>
 #include <spdlog/common.h>
 #include <string_view>
@@ -19,7 +20,7 @@ Level level_from_string(std::string level) {
         return spdlog::level::off;
     if (auto l = spdlog::level::from_str(level); l != spdlog::level::off)
         return l;
-    throw std::invalid_argument{fmt::format("Invalid log level '{}'", level)};
+    throw std::invalid_argument{"Invalid log level '{}'"_format(level)};
 }
 
 }  // namespace oxen::log

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -1,6 +1,7 @@
 #include <oxen/log.hpp>
 #include <oxen/log/type.hpp>
 #include <oxen/log/catlogger.hpp>
+#include <oxen/log/format.hpp>
 
 #include <chrono>
 
@@ -90,7 +91,7 @@ namespace {
                     sink = std::make_shared<spdlog::sinks::stderr_sink_mt>();
                 else
                     throw std::invalid_argument{
-                            fmt::format("{} is not a valid target for type=Print logging", arg)};
+                            "{} is not a valid target for type=Print logging"_format(arg)};
                 break;
 
             case Type::File:

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -1,5 +1,6 @@
 #include <oxen/log/type.hpp>
 #include <oxen/log/internal.hpp>
+#include <oxen/log/format.hpp>
 #include <fmt/core.h>
 
 namespace oxen::log {
@@ -14,7 +15,7 @@ Type type_from_string(std::string type) {
     if (type == "system" || type == "syslog")
         return Type::System;
 
-    throw std::invalid_argument{fmt::format("Invalid log type '{}'", type)};
+    throw std::invalid_argument{"Invalid log type '{}'"_format(type)};
 }
 
 std::string_view to_string(Type type) {


### PR DESCRIPTION
```C++
fmt::format("foo {}", 42);
```

now becomes:

```c++
"foo {}"_format(42);
```