### PR TITLE
Support a list of source root prefixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.13...3.23)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-project(oxen-logging VERSION 1.0.1 LANGUAGES CXX)
+project(oxen-logging VERSION 1.0.2 LANGUAGES CXX)
 
-set(OXEN_LOGGING_SOURCE_ROOT "" CACHE PATH "Base path to strip from log message filenames")
+set(OXEN_LOGGING_SOURCE_ROOT "" CACHE PATH "Base path(s) to strip from log message filenames; separate multiple paths with \";\"")
 option(OXEN_LOGGING_FORCE_SUBMODULES "Force use of the bundled fmt/spdlog rather than looking for system packages" OFF)
 option(OXEN_LOGGING_RELEASE_TRACE "Enable trace logging in release builds" OFF)
 option(OXEN_LOGGING_FMT_HEADER_ONLY "Use fmt in header-only mode" OFF)
@@ -72,8 +72,18 @@ target_link_libraries(oxen-logging PUBLIC ${OXEN_LOGGING_FMT_TARGET} ${OXEN_LOGG
 target_compile_features(oxen-logging PUBLIC cxx_std_17)
 
 if(OXEN_LOGGING_SOURCE_ROOT)
-    message(STATUS "Stripping source root ${OXEN_LOGGING_SOURCE_ROOT} from log paths")
-    target_compile_definitions(oxen-logging PUBLIC "OXEN_LOGGING_SOURCE_ROOT=\"${OXEN_LOGGING_SOURCE_ROOT}\"")
+    set(paths)
+    foreach(path ${OXEN_LOGGING_SOURCE_ROOT})
+        string(REGEX REPLACE "([\\\"])" "\\\\\\1" path_escaped "${path}")
+        list(APPEND paths "\"${path_escaped}\"")
+        message(STATUS "Stripping source root ${path} (${path_escaped}) from log paths")
+    endforeach()
+    list(LENGTH paths pathlen)
+    list(JOIN paths ", " paths)
+    target_compile_definitions(oxen-logging PUBLIC
+        OXEN_LOGGING_SOURCE_ROOTS=${paths}
+        OXEN_LOGGING_SOURCE_ROOTS_LEN=${pathlen}
+    )
 else()
     message(STATUS "Source root log path stripping disabled")
 endif()

--- a/include/oxen/log/internal.hpp
+++ b/include/oxen/log/internal.hpp
@@ -19,22 +19,27 @@ spdlog::sink_ptr make_sink(Type type, const std::string& file);
 
 bool is_ansicolor_sink(const spdlog::sink_ptr& sink);
 
-template <typename... More>
-inline static constexpr std::string_view strip_prefixes(
-        std::string_view str, std::string_view prefix, More&&... more_prefixes) {
-    if (str.substr(0, prefix.size()) == prefix)
-        str.remove_prefix(prefix.size());
-    if constexpr (sizeof...(More) == 0)
-        return str;
-    else
-        return strip_prefixes(str, std::forward<More>(more_prefixes)...);
-}
+#ifndef OXEN_LOGGING_SOURCE_ROOTS_LEN
+#define OXEN_LOGGING_SOURCE_ROOTS_LEN 0
+#endif
+
+inline constexpr std::array<std::string_view, OXEN_LOGGING_SOURCE_ROOTS_LEN> source_prefixes = {
+#ifdef OXEN_LOGGING_SOURCE_ROOTS
+        OXEN_LOGGING_SOURCE_ROOTS,
+#endif
+};
 
 inline auto spdlog_sloc(const slns::source_location& loc) {
     std::string_view filename{loc.file_name()};
-#ifdef OXEN_LOGGING_SOURCE_ROOT
-    filename = strip_prefixes(filename, OXEN_LOGGING_SOURCE_ROOT, "..", "/");
-#endif
+    for (const auto& prefix : source_prefixes) {
+        if (filename.substr(0, prefix.size()) == prefix) {
+            filename.remove_prefix(prefix.size());
+            if (!filename.empty() && filename[0] == '/')
+                filename.remove_prefix(1);
+        }
+    }
+    while (filename.substr(0, 3) == "../")
+        filename.remove_prefix(3);
 
     return spdlog::source_loc{filename.data(), static_cast<int>(loc.line()), loc.function_name()};
 }


### PR DESCRIPTION
Some code bases have code in multiple places (e.g. src/ and include/) but we have no way to strip them so would have to strip the project root and have the `src/` or `include/` prefixed on everything.

This commit allows a list of prefixes and attempts to remove them all. It also tweaks the way "../" and "/" get removed which ought to make it slightly more robust against weird paths.