### PR TITLE
GNU error handling for fmt version 10.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,11 @@ add_library(oxen-logging STATIC
     src/log.cpp
     src/type.cpp
 )
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL GNU AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13 AND fmt_VERSION VERSION_LESS 10.0.1)
+    target_compile_options(oxen-logging PUBLIC -Wno-error=dangling-reference)
+endif()
+
 target_include_directories(oxen-logging PUBLIC include)
 target_link_libraries(oxen-logging PUBLIC ${OXEN_LOGGING_FMT_TARGET} ${OXEN_LOGGING_SPDLOG_TARGET})
 target_compile_features(oxen-logging PUBLIC cxx_std_17)


### PR DESCRIPTION
Okay so this is only an issue if:
- Compiling with [gcc-13](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106393), which introduced dangling reference errors
- gcc-13 is only available on [debian sid + trixie currently](https://packages.debian.org/sid/gcc-13), which is why CI builds are failing on it
- fmt is a version prior to [10.0.1](https://github.com/fmtlib/fmt/commit/ef55d4f52ec527668a8e910a56ea79d9b939dbc2)

BUT in case all 3 are true, we presumably have a very specific fix for it