### PR TITLE
C++20 compatibility fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.13...3.23)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-project(oxen-logging VERSION 1.0.2 LANGUAGES CXX)
+project(oxen-logging VERSION 1.0.3 LANGUAGES CXX)
 
 set(OXEN_LOGGING_SOURCE_ROOT "" CACHE PATH "Base path(s) to strip from log message filenames; separate multiple paths with \";\"")
 option(OXEN_LOGGING_FORCE_SUBMODULES "Force use of the bundled fmt/spdlog rather than looking for system packages" OFF)


### PR DESCRIPTION
- Updates the `_format` user-defined literal to work when under C++20. In addition to just making it work, this effectively redoes it using new C++20 tricks for string literal storage so that, under C++20, you get compile-time argument checking so that things like missing arguments (such as `"{}{}"_format(123)`) or invalid arguments (such as `"{:d}"_format("foo")`) are now caught at compile-time under C++20.

- Fixes a timestamp log statement that fmt::format was unhappy with under C++20 (for a similar reason to the above w.r.t. fmt's constexpr format handling).