### PR TITLE
Fix crash at destruction with multiple static libs

### DIFF
--- a/src/catlogger.cpp
+++ b/src/catlogger.cpp
@@ -19,29 +19,38 @@ std::shared_ptr<spdlog::sinks::dist_sink_mt> master_sink = get_master_sink();
 
 namespace detail {
 
-    OXEN_LOGGING_EXPORT std::unordered_map<std::string, logger_ptr> loggers;
-    OXEN_LOGGING_EXPORT std::mutex loggers_mutex;
-    OXEN_LOGGING_EXPORT Level loggers_default_level = Level::info;
+    OXEN_LOGGING_EXPORT std::unordered_map<std::string, logger_ptr>& loggers() {
+        static std::unordered_map<std::string, logger_ptr> loggers_impl;
+        return loggers_impl;
+    }
+    OXEN_LOGGING_EXPORT std::mutex& loggers_mutex() {
+        static std::mutex loggers_mutex_impl;
+        return loggers_mutex_impl;
+    }
+    OXEN_LOGGING_EXPORT Level& loggers_default_level() {
+        static Level default_level_impl = Level::info;
+        return default_level_impl;
+    }
 
     void set_default_catlogger_level(Level level) {
-        loggers_default_level = level;
+        loggers_default_level() = level;
     }
 
     Level get_default_catlogger_level() {
-        return loggers_default_level;
+        return loggers_default_level();
     }
 
 }  // namespace detail
 
 void CategoryLogger::find_or_make_logger() {
-    std::lock_guard lock{detail::loggers_mutex};
+    std::lock_guard lock{detail::loggers_mutex()};
     if (have_logger)
         return;
 
-    auto& known_logger = detail::loggers[name];
+    auto& known_logger = detail::loggers()[name];
     if (!known_logger) {
         known_logger = std::make_shared<spdlog::logger>(name, master_sink);
-        known_logger->set_level(detail::loggers_default_level);
+        known_logger->set_level(detail::loggers_default_level());
     }
 
     logger = known_logger;
@@ -51,9 +60,9 @@ void CategoryLogger::find_or_make_logger() {
 void for_each_cat_logger(
         std::function<void(const std::string& name, spdlog::logger&)> f,
         std::function<void()> and_then) {
-    std::lock_guard lock{detail::loggers_mutex};
+    std::lock_guard lock{detail::loggers_mutex()};
     if (f)
-        for (auto& [name, logger] : detail::loggers)
+        for (auto& [name, logger] : detail::loggers())
             f(name, *logger);
     if (and_then)
         and_then();


### PR DESCRIPTION
If compiling oxen-logging statically with multiple instances of the static library (such as libsession-util which includes a static libquic with its own static oxen-logging.a), the `loggers` destructor would fire multiple times on the same `loggers` instance, because of static linking rules.  Normally, when static linking, each instance would be in its own private address space and so it would be two unrelated destructions on two unrelated objects.  However the OXEN_LOGGING_EXPORT here forced them to have the same address, but that doesn't defer the destruction, and so we would get two destructions (and, also, two constructions) at the same instance, which is bad.

This fixes it by hidding the unordered_map inside an exported function, so that we ought to get the same unique-instance behaviour, and applying OXEN_LOGGING_EXPORT to the function instead of the instance, so that there should only ever be one instance because there should only be one instance of the function that returns it.