### PR TITLE
Add log string parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15 CACHE STRING "macOS deployment target (Apple clang only)")
 
-project(oxen-logging VERSION 1.1.1 LANGUAGES CXX)
+project(oxen-logging VERSION 1.2.0 LANGUAGES CXX)
 
 option(OXEN_LOGGING_WARNINGS_AS_ERRORS "treat all warnings as errors. turn off for development, on for release" OFF)
 option(OXEN_LOGGING_FORCE_SUBMODULES "Force use of the bundled fmt/spdlog rather than looking for system packages" OFF)

--- a/include/oxen/log/catlogger.hpp
+++ b/include/oxen/log/catlogger.hpp
@@ -26,7 +26,7 @@ struct CategoryLogger {
 
     /// Constructor: this stores the name; actually categorized logger initialization is deferred to
     /// the first call to `operator const logger_ptr&` or dereference.
-    explicit CategoryLogger(std::string name) : name{std::move(name)} {}
+    explicit CategoryLogger(std::string name);
 
     /// Returns a shared_ptr to a spdlog::logger for this logging category.  The first time this is
     /// called the logger is initialized: either finding an existing logger (if one with the same
@@ -56,6 +56,11 @@ inline CategoryLogger Cat(std::string cat) {
 void for_each_cat_logger(
         std::function<void(const std::string& name, spdlog::logger& logger)> f,
         std::function<void()> and_then = nullptr);
+
+/// Similar to the above, but just iterates through known category names, even if those names don't
+/// have existing underlying loggers yet.
+void for_each_cat_name(
+        std::function<void(const std::string& name)> f, std::function<void()> and_then = nullptr);
 
 namespace detail {
 

--- a/include/oxen/log/level.hpp
+++ b/include/oxen/log/level.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <list>
 #include <optional>
 #include <string_view>
 
@@ -19,8 +20,76 @@ std::string_view to_string(Level lvl);
 /// - "info"
 /// - "warn" or "warning"
 /// - "error" or "err"
-/// - "critical"
-/// - "none" or "off"
+/// - "critical" or "crit"
+/// - "none", "off", or "disabled"
+///
+/// Additional level strings can be added by an application using the add_level_compat_string(), but
+/// this is discouraged except where needed to maintain backwards compatibility.
 Level level_from_string(std::string level);
+
+/// Adds a string to parse as a given log level for backwards compatibility.  This affects both
+/// `level_from_string` and `extract_categories`.  This is not recommended for any new code, but
+/// rather for older code (such as oxen-core) where existing config files may specify log levels as
+/// "1" or "wrn".
+void add_level_compat_string(std::string key, Level level);
+
+// Return type of extract_categories.
+struct LogCats {
+    // Contains the default level, if one was given.
+    std::optional<Level> default_level;
+    // Contains the levels to apply to all given (or matched) categories.
+    std::unordered_map<std::string, Level> cat_levels;
+    // Returns true if neither a defaul nor any category levels were parsed or matched at all.
+    bool empty() const { return !default_level && cat_levels.empty(); }
+
+    // Applies the settings in the object to the global logger.  This string is reconstructed
+    // according to the parsed and matched results and so will not necessarily exactly match the
+    // input.
+    //
+    // If the optional callback is set then it will be called immediately after applying the default
+    // level (it is not called at all if the category string does not specify a default).  This is
+    // intended for code to have a global log level imply tweaks levels for some categories: for
+    // instance, oxen-core at a global (and default) "WARNING" level puts some unnecessarily verbose
+    // categories into ERR level, and some others into "INFO" level, and makes similar changes at a
+    // global INFO level.  The callback is given the global Level that has just been applied to all
+    // categories.
+    std::list<std::string> apply(std::function<void(Level)> amend_default = nullptr);
+};
+
+/// Parses a user-provided logging string of levels and/or categories and returns an object
+/// containing the parsed results (which can be applied by invoking `.apply()` on it).  The input
+/// string consists of any number of the following, separated by whitespace, commas (,), or
+/// semicolons (;).
+///
+/// - *=LEVEL, where LEVEL is warning, debug, and so on.  This resets *all* log categories to the
+///   given log level, and so typically should be the first (or only) argument given.
+/// - A single level string by itself, such as `critical` or `off`.  This is an alias for `*=LEVEL`.
+/// - CAT=LEVEL where CAT is a log category ("quic") and LEVEL is a level such as `trace` or `info`.
+/// - Category globbing, such as `db.*=debug` or `*test=off` sets the level of all matching, known
+///   log categories at the time the levels are parsed.  Note that log categories are dynamic and so
+///   a category that is not yet created (such as an "on the fly" `log::Cat("xyz")` in a log
+///   statement, or from a library that is dynamically loaded after this call) may not be matched if
+///   the code path that creates it has never been called.
+/// - A `:` can also be given instead of `=` (for example: `MyCat:warning`) for backwards
+///   compatibility, but its use is discouraged.
+///
+/// Categories are case-sensitive; log levels are not.  Allowed level strings are: "trace",
+/// "debug"/"dbg", "info", "warning"/"warn", "error"/"err", "critical"/"crit", and
+/// "off"/"disabled"/"none".  (Additional level strings for backwards compatibility can be added by
+/// calling `add_level_compat_string()`).
+///
+/// Levels are applied in the order given, and so generally the more general values should be first.
+/// For example `*=ERROR, test*=WARN, test42=INFO` sets the level to info for `test42`, warning for
+/// `test` and `test123`, and error for everything else.  However, `test42=INFO, test*=WARN,
+/// *=ERROR` is likely a mistake: it would apply error log levels to all categories.
+///
+/// This call itself makes error logs to a `logging` category on unparseable input values, and an
+/// info log statement is also emitted when applying the categories.
+LogCats extract_categories(std::string_view categories);
+
+/// Shortcut for `extract_categories(string).apply()`.
+inline void apply_categories(std::string_view categories) {
+    extract_categories(categories).apply();
+}
 
 }  // namespace oxen::log

--- a/src/catlogger.cpp
+++ b/src/catlogger.cpp
@@ -42,11 +42,18 @@ namespace detail {
 
 }  // namespace detail
 
-void CategoryLogger::find_or_make_logger() {
+CategoryLogger::CategoryLogger(std::string name_) : name{std::move(name_)} {
     std::lock_guard lock{detail::loggers_mutex()};
+    // Insert an empty shared_ptr here because we don't want to create the underlying logger until
+    // first use, but we at least want to know the category exists.
+    detail::loggers()[name];
+}
+
+void CategoryLogger::find_or_make_logger() {
     if (have_logger)
         return;
 
+    std::lock_guard lock{detail::loggers_mutex()};
     auto& known_logger = detail::loggers()[name];
     if (!known_logger) {
         known_logger = std::make_shared<spdlog::logger>(name, master_sink);
@@ -63,7 +70,18 @@ void for_each_cat_logger(
     std::lock_guard lock{detail::loggers_mutex()};
     if (f)
         for (auto& [name, logger] : detail::loggers())
-            f(name, *logger);
+            if (logger)
+                f(name, *logger);
+    if (and_then)
+        and_then();
+}
+
+void for_each_cat_name(
+        std::function<void(const std::string& name)> f, std::function<void()> and_then) {
+    std::lock_guard lock{detail::loggers_mutex()};
+    if (f)
+        for (auto& [name, logger] : detail::loggers())
+            f(name);
     if (and_then)
         and_then();
 }

--- a/src/level.cpp
+++ b/src/level.cpp
@@ -1,11 +1,49 @@
-#include <oxen/log/level.hpp>
-#include <oxen/log/internal.hpp>
+#include <oxen/log.hpp>
 #include <oxen/log/format.hpp>
+
+#include <shared_mutex>
+#include <span>
 #include <stdexcept>
-#include <spdlog/common.h>
 #include <string_view>
 
+#include <fmt/ranges.h>
+
+#if defined(_WIN32) || defined(WIN32)
+#define OXEN_LOGGING_EXPORT __declspec(dllexport)
+#else
+#define OXEN_LOGGING_EXPORT __attribute__((visibility("default")))
+#endif
+
 namespace oxen::log {
+
+static auto logcat = Cat("logging");
+
+using namespace std::literals;
+
+namespace detail {
+    OXEN_LOGGING_EXPORT std::unordered_map<std::string, Level>& levels() {
+        static std::unordered_map<std::string, Level> levels_impl{
+                {"off"s, Level::off},
+                {"none"s, Level::off},
+                {"disable"s, Level::off},
+                {"disabled"s, Level::off},
+                {"critical"s, Level::critical},
+                {"crit"s, Level::critical},
+                {"error"s, Level::err},
+                {"err"s, Level::err},
+                {"warning"s, Level::warn},
+                {"warn"s, Level::warn},
+                {"info"s, Level::info},
+                {"debug"s, Level::debug},
+                {"trace"s, Level::trace},
+        };
+        return levels_impl;
+    }
+    OXEN_LOGGING_EXPORT std::shared_mutex& levels_mutex() {
+        static std::shared_mutex levels_mutex_impl;
+        return levels_mutex_impl;
+    }
+}  // namespace detail
 
 std::string_view to_string(Level lvl) {
     auto l = spdlog::level::to_string_view(lvl);
@@ -15,12 +53,119 @@ std::string_view to_string(Level lvl) {
 Level level_from_string(std::string level) {
     detail::make_lc(level);
 
-    // Special case "off" because the spdlog call below returns off for unknown inputs
-    if (level == "off" || level == "none")
-        return spdlog::level::off;
-    if (auto l = spdlog::level::from_str(level); l != spdlog::level::off)
-        return l;
+    std::shared_lock lock{detail::levels_mutex()};
+    auto& levels = detail::levels();
+    if (auto it = levels.find(level); it != levels.end())
+        return it->second;
+
     throw std::invalid_argument{"Invalid log level '{}'"_format(level)};
+}
+
+void add_level_compat_string(std::string key, Level level) {
+    std::unique_lock lock{detail::levels_mutex()};
+    detail::levels()[std::move(key)] = level;
+}
+
+static std::vector<std::string_view> split_any(
+        std::string_view str, const std::string_view delims, bool trim) {
+    std::vector<std::string_view> results;
+    for (size_t pos = str.find_first_of(delims); pos != std::string_view::npos;
+         pos = str.find_first_of(delims)) {
+        if (!trim || !results.empty() || pos > 0)
+            results.push_back(str.substr(0, pos));
+        size_t until = str.find_first_not_of(delims, pos + 1);
+        if (until == std::string_view::npos)
+            str.remove_prefix(str.size());
+        else
+            str.remove_prefix(until);
+    }
+    if (!trim || str.size())
+        results.push_back(str);
+    else
+        while (!results.empty() && results.back().empty())
+            results.pop_back();
+    return results;
+}
+
+LogCats extract_categories(std::string_view categories) {
+    LogCats result;
+    for (auto cat : split_any(categories, " ,;", true)) {
+        auto pieces = split_any(cat, ":=", true);
+        if (pieces.size() < 1 || pieces.size() > 2) {
+            error(logcat,
+                  "Invalid or unparseable log category/level '{}'; expected 'level' or "
+                  "'category=level'",
+                  cat);
+            continue;
+        }
+        Level lvl;
+        try {
+            lvl = level_from_string(std::string{pieces.back()});
+        } catch (const std::invalid_argument&) {
+            error(logcat, "Invalid log level '{}' in log input '{}'", pieces.back(), cat);
+            continue;
+        }
+        auto cat_name = pieces.size() == 1 ? "*"sv : pieces.front();
+
+        if (cat_name == "*"sv) {
+            result.default_level = lvl;
+            // Any categories up to this point just get wiped out by the default resetting
+            // everything:
+            result.cat_levels.clear();
+        } else if (auto pos = cat_name.find('*'); pos != std::string_view::npos) {
+            auto matches = split_any(cat_name, "*"sv, false);
+            for_each_cat_name([&result,
+                               lvl,
+                               &prefix = matches.front(),
+                               suffix = matches.back(),
+                               middle = std::span{matches}.subspan(1, matches.size() - 2)](
+                                      const std::string& name) {
+                std::string_view remaining{name};
+                if (!prefix.empty()) {
+                    if (!remaining.starts_with(prefix))
+                        return;
+                    remaining.remove_prefix(prefix.size());
+                }
+                if (!suffix.empty()) {
+                    if (!remaining.ends_with(suffix))
+                        return;
+                    remaining.remove_suffix(suffix.size());
+                }
+                for (const auto& m : middle) {
+                    if (auto p = remaining.find(m); p != std::string_view::npos)
+                        remaining.remove_prefix(p + m.size());
+                    else
+                        return;
+                }
+
+                result.cat_levels[name] = lvl;
+            });
+        } else {
+            result.cat_levels[std::string{pieces.front()}] = lvl;
+        }
+    }
+
+    return result;
+}
+
+std::list<std::string> LogCats::apply(std::function<void(Level)> amend_default) {
+    std::list<std::string> applied;
+    if (default_level) {
+        reset_level(*default_level);
+        if (amend_default)
+            amend_default(*default_level);
+        applied.push_back(fmt::format("*={}", to_string(*default_level)));
+    }
+
+    for (const auto& [cat, lvl] : cat_levels) {
+        set_level(cat, lvl);
+        applied.push_back(fmt::format("{}={}", cat, to_string(lvl)));
+    }
+
+    if (!applied.empty())
+        info(logcat, "Applied log categories: {}", fmt::join(applied, ", "));
+
+    return applied;
 }
 
 }  // namespace oxen::log


### PR DESCRIPTION
This adapts the category log string parsing from oxen-core into oxen-logging so that it can be used in other code bases as well to cleanly set log levels of different categories.